### PR TITLE
Feat: Standardize Job Responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
-# OpenRouter Configuration
-OPENROUTER_API_KEY="Your OPENROUTER_API_KEY here"
-OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
-GEMINI_MODEL=google/gemini-2.0-flash-thinking-exp:free
+OPENROUTER_API_KEY=YOUR_OPENROUTER_API_KEY_HERE
+
+# Optional: Specify preferred models for OpenRouter, e.g.:
+# GEMINI_MODEL="google/gemini-pro"
+# PERPLEXITY_MODEL="perplexity/pplx-7b-online"
+
+# Optional: Specify your desired log level (e.g., 'info', 'debug', 'warn', 'error')
+# LOG_LEVEL="info"
+
+# Optional: Port for the SSE server if not using the default (3000)
+# SSE_PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -97,4 +97,8 @@ VibeCoderOutput/
 # Documentation (if not intended for commit)
 docs/
 
+# Windsurf and Plan Documentation
+.windsurf/
+plan_docs/
+
 # Untracked file to ignore

--- a/llm_config.json
+++ b/llm_config.json
@@ -1,18 +1,18 @@
 {
   "llm_mapping": {
-    "research_query": "perplexity/sonar-deep-research",
-    "sequential_thought_generation": "google/gemini-2.0-flash-thinking-exp:free",
-    "task_list_initial_generation": "google/gemini-2.0-flash-thinking-exp:free",
-    "task_list_decomposition": "deepseek/deepseek-chat-v3-0324",
-    "code_refactoring": "google/gemini-2.0-flash-thinking-exp:free",
-    "code_stub_generation": "google/gemini-2.0-flash-thinking-exp:free",
-    "prd_generation": "google/gemini-2.0-flash-thinking-exp:free",
-    "rules_generation": "deepseek/deepseek-chat-v3-0324",
-    "user_stories_generation": "deepseek/deepseek-chat-v3-0324",
-    "git_summary_generation": "google/gemini-2.0-flash-thinking-exp:free",
-    "dependency_analysis": "google/gemini-2.0-flash-thinking-exp:free",
-    "fullstack_starter_kit_generation": "google/gemini-2.0-flash-thinking-exp:free",
-    "workflow_step_execution": "deepseek/deepseek-chat-v3-0324",
-    "default_generation": "deepseek/deepseek-chat-v3-0324"
+    "research_query": "perplexity/llama-3.1-sonar-small-128k-online",
+    "sequential_thought_generation": "google/gemini-2.5-flash-preview",
+    "task_list_initial_generation": "google/gemini-2.5-flash-preview",
+    "task_list_decomposition": "google/gemini-2.5-flash-preview",
+    "code_refactoring": "google/gemini-2.5-flash-preview",
+    "code_stub_generation": "google/gemini-2.5-flash-preview",
+    "prd_generation": "google/gemini-2.5-flash-preview",
+    "rules_generation": "google/gemini-2.5-flash-preview",
+    "user_stories_generation": "google/gemini-2.5-flash-preview",
+    "git_summary_generation": "google/gemini-2.5-flash-preview",
+    "dependency_analysis": "google/gemini-2.5-flash-preview",
+    "fullstack_starter_kit_generation": "google/gemini-2.5-flash-preview",
+    "workflow_step_execution": "google/gemini-2.5-flash-preview",
+    "default_generation": "google/gemini-2.5-flash-preview"
   }
 }

--- a/mcp-config.json
+++ b/mcp-config.json
@@ -54,6 +54,11 @@
       "description": "Runs a predefined sequence of tool calls (a workflow) based on a workflow name and input parameters.",
       "use_cases": ["run workflow", "execute plan", "start process", "automate sequence", "execute workflow", "run automation"],
       "input_patterns": ["run workflow {workflowName}", "start {workflowName} workflow with input {workflowInput}", "execute the {workflowName} plan"]
+    },
+    "get-job-result": {
+      "description": "Retrieves the status and result of a background job previously initiated by another tool.",
+      "use_cases": ["job status", "check job", "get job result", "task progress", "background task status"],
+      "input_patterns": ["get result for job {jobId}", "check status of job {jobId}", "what is the result of {jobId}"]
     }
   }
 }

--- a/src/services/job-response-formatter/index.ts
+++ b/src/services/job-response-formatter/index.ts
@@ -1,0 +1,36 @@
+// src/services/job-response-formatter/index.ts
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { JobStatus } from '../job-manager/index.js'; // Assuming JobStatus is needed/useful
+
+/**
+ * Formats the initial response for a background job that has been successfully initiated.
+ *
+ * @param jobId The unique identifier for the job.
+ * @param toolName The internal, registered name of the tool (e.g., "generate-prd").
+ * @param toolDisplayName A user-friendly name for the tool (e.g., "PRD Generator").
+ * @returns A CallToolResult object suitable for immediate return to the client.
+ */
+export function formatBackgroundJobInitiationResponse(
+  jobId: string,
+  toolName: string,
+  toolDisplayName: string
+): CallToolResult {
+  const userMessage = `Your request to use the '${toolDisplayName}' tool has been initiated with Job ID: ${jobId}. Your request will be completed shortly.`;
+  const retrievalPrompt = `To check the status and retrieve the output of your request with Job ID ${jobId}, please use the 'get-job-result' tool with the following parameters: { "jobId": "${jobId}" }.`;
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify({
+          jobId: jobId,
+          message: userMessage,
+          retrievalPrompt: retrievalPrompt,
+          status: JobStatus.PENDING, // Reflecting the initial status
+          toolName: toolName, // The actual tool name for consistency/internal use
+        }),
+      },
+    ],
+    isError: false,
+  };
+}

--- a/src/tools/code-refactor-generator/index.ts
+++ b/src/tools/code-refactor-generator/index.ts
@@ -11,6 +11,7 @@ import logger from '../../logger.js'; // Adjust path if necessary
 import { selectModelForTask } from '../../utils/configLoader.js'; // Import the new utility
 import { jobManager, JobStatus } from '../../services/job-manager/index.js'; // Import job manager & status
 import { sseNotifier } from '../../services/sse-notifier/index.js'; // Import SSE notifier
+import { formatBackgroundJobInitiationResponse } from '../../services/job-response-formatter/index.js';
 
 // TODO: Consider moving cleanCodeOutput to a shared utils/codeUtils.ts
 function cleanCodeOutput(rawOutput: string): string {
@@ -77,10 +78,11 @@ export const refactorCode: ToolExecutor = async (
   logger.info({ jobId, tool: 'refactorCode', sessionId }, 'Starting background job.');
 
   // Return immediately
-  const initialResponse: CallToolResult = {
-    content: [{ type: 'text', text: `Code refactoring started. Job ID: ${jobId}` }],
-    isError: false,
-  };
+  const initialResponse = formatBackgroundJobInitiationResponse(
+    jobId,
+    'Code Refactoring',
+    'Your code refactoring request has been submitted. You can retrieve the result using the job ID.'
+  );
 
   // --- Execute Long-Running Logic Asynchronously ---
   setImmediate(async () => {

--- a/src/tools/code-stub-generator/index.ts
+++ b/src/tools/code-stub-generator/index.ts
@@ -10,6 +10,7 @@ import logger from '../../logger.js';
 import { selectModelForTask } from '../../utils/configLoader.js'; // Import the new utility
 import { jobManager, JobStatus } from '../../services/job-manager/index.js'; // Import job manager & status
 import { sseNotifier } from '../../services/sse-notifier/index.js'; // Import SSE notifier
+import { formatBackgroundJobInitiationResponse } from '../../services/job-response-formatter/index.js';
 
 const CODE_STUB_SYSTEM_PROMPT = `You are an expert code generation assistant. Your task is to generate a clean, syntactically correct code stub based ONLY on the user's specifications.
 
@@ -109,10 +110,11 @@ export const generateCodeStub: ToolExecutor = async (
   logger.info({ jobId, tool: 'generateCodeStub', sessionId }, 'Starting background job.');
 
   // Return immediately
-  const initialResponse: CallToolResult = {
-    content: [{ type: 'text', text: `Code stub generation started. Job ID: ${jobId}` }],
-    isError: false,
-  };
+  const initialResponse = formatBackgroundJobInitiationResponse(
+    jobId,
+    'Code Stub Generation',
+    'Your code stub generation request has been submitted. You can retrieve the result using the job ID.'
+  );
 
   // ---> Step 2.5(CSG).4: Wrap Logic in Async Block <---
   setImmediate(async () => {

--- a/src/tools/git-summary-generator/index.ts
+++ b/src/tools/git-summary-generator/index.ts
@@ -8,6 +8,7 @@ import logger from '../../logger.js'; // Adjust path if necessary
 import { jobManager, JobStatus } from '../../services/job-manager/index.js'; // Import job manager & status
 import { sseNotifier } from '../../services/sse-notifier/index.js'; // Import SSE notifier
 import { OpenRouterConfig } from '../../types/workflow.js'; // Import OpenRouterConfig for type consistency
+import { formatBackgroundJobInitiationResponse } from '../../services/job-response-formatter/index.js';
 
 // Define the executor function
 export const generateGitSummary: ToolExecutor = async (
@@ -29,10 +30,11 @@ export const generateGitSummary: ToolExecutor = async (
   logger.info({ jobId, tool: 'generateGitSummary', sessionId }, 'Starting background job.');
 
   // Return immediately
-  const initialResponse: CallToolResult = {
-    content: [{ type: 'text', text: `Git summary generation started. Job ID: ${jobId}` }],
-    isError: false,
-  };
+  const initialResponse = formatBackgroundJobInitiationResponse(
+    jobId,
+    'Git Summary Generation',
+    'Your Git summary generation request has been submitted. You can retrieve the result using the job ID.'
+  );
 
   // ---> Step 2.5(GSG).4: Wrap Logic in Async Block <---
   setImmediate(async () => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -12,6 +12,7 @@ import './code-refactor-generator/index.js';
 import './git-summary-generator/index.js';
 import './dependency-analyzer/index.js'; // Added import for the dependency analyzer tool
 import './workflow-runner/index.js'; // Add this line
+import './job-result-retriever/index.js'; // Added import for the job result retriever tool
 
 // Note: process-request is currently registered in src/services/request-processor/index.ts
 // If it were moved to src/tools/, its import would go here too.

--- a/src/tools/job-result-retriever/README.md
+++ b/src/tools/job-result-retriever/README.md
@@ -10,10 +10,84 @@ This tool retrieves the final result of an asynchronous background job that was 
 | :-------- | :------- | :------------------------------------------- | :------- |
 | `jobId`   | `string` | The unique ID of the job whose result is needed. | Yes      |
 
+### Example Input JSON
+
+```json
+{
+  "jobId": "some-unique-job-identifier-123"
+}
+```
+
 ## Outputs
 
 *   **Primary Output:** The `CallToolResult` object that was stored by the background job upon its completion or failure. This could contain the final generated content (e.g., task list, code snippet) or error details.
 *   **File Storage:** This tool does not save any files itself; it retrieves results potentially saved by other tools.
+
+## Output Schema
+
+ 
+The tool returns a standard `CallToolResult` object. The `content` field within this result will be an array, typically containing a single text element. The text describes the job's current status or provides its final result.
+
+The structure of the `text` content varies based on the job's state:
+*   **Job PENDING**: Indicates the job is queued.
+  * Example `text`: `Job 'some-unique-job-identifier-123' is pending.`
+*   **Job RUNNING**: Indicates the job is actively processing.
+  * Example `text`: `Job 'some-unique-job-identifier-123' is running.`
+*   **Job COMPLETED Successfully**:
+  * If the job produced a structured result, it's often stringified within the `text`.
+    Example `text`: `Job 'some-unique-job-identifier-123' completed successfully. Result: { "output": "This is the detailed job output" }`
+  * If the job completed with no specific additional output beyond success.
+    Example `text`: `Job 'some-unique-job-identifier-123' completed successfully. No additional result output.`
+*   **Job FAILED**: Indicates an error occurred during job execution. The `text` will contain details about the failure.
+  * Example `text`: `Job 'some-unique-job-identifier-123' failed. Error: An error message detailing the failure.`
+*   **Job ID Not Found**: If the provided `jobId` does not correspond to any known job.
+  * Example `text`: `Job with ID 'invalid-job-id' not found.`
+
+### Example Output JSON (for a COMPLETED job with a structured result)
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Job 'some-unique-job-identifier-123' completed successfully. Result: { \"data\": \"final output\" }"
+    }
+  ],
+  "isError": false
+}
+```
+
+*(Note: The `isError` flag in the outer `CallToolResult` will be `false` if the `get-job-result` tool itself executed successfully in retrieving the status. The success or failure of the *underlying* job is conveyed within the `text` content.)*
+
+### Example Output JSON (for a RUNNING job)
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Job 'some-unique-job-identifier-123' is running."
+    }
+  ],
+  "isError": false
+}
+```
+
+### Example Output JSON (for a FAILED job reported by `get-job-result`)
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Job 'some-unique-job-identifier-123' failed. Error: Something went wrong during execution."
+    }
+  ],
+  "isError": false 
+}
+```
+
+*(The `get-job-result` tool itself succeeded; it's reporting the status of the job which failed).*
 
 ## Workflow
 
@@ -56,6 +130,44 @@ flowchart TD
 
 Invoked via AI Assistant (after getting a Job ID from another tool):
 `"Get the result for job ID 123e4567-e89b-12d3-a456-426614174000"`
+
+### Conceptual Client-Side JavaScript Example
+
+A client application would typically call this tool periodically after initiating a long-running operation that returned a `jobId`.
+
+```javascript
+// Conceptual client-side JavaScript
+async function checkJobStatus(mcpClient, jobId) {
+  try {
+    const result = await mcpClient.callTool('get-job-result', { jobId });
+    if (result.isError) {
+      console.error("Error calling get-job-result tool:", result.content[0]?.text || "Unknown error");
+    } else {
+      console.log("Job Status/Result:", result.content[0]?.text);
+      // Further processing based on the text content.
+      // For example, parse the result if the job completed successfully.
+      const textContent = result.content[0]?.text || "";
+      if (textContent.includes("completed successfully. Result:")) {
+        // Attempt to parse the result part
+        try {
+          const resultJsonString = textContent.substring(textContent.indexOf("Result:") + "Result:".length).trim();
+          const jobOutput = JSON.parse(resultJsonString);
+          console.log("Parsed Job Output:", jobOutput);
+        } catch (parseError) {
+          console.warn("Could not parse job output from text:", parseError);
+        }
+      }
+    }
+  } catch (error) {
+    console.error("Exception while calling get-job-result:", error);
+  }
+}
+
+// Example usage:
+// const myJobId = "some-unique-job-identifier-123";
+// // Periodically check status, e.g., using setInterval or a polling mechanism
+// // setInterval(() => checkJobStatus(myMcpClientInstance, myJobId), 5000); 
+```
 
 ## Error Handling
 

--- a/src/tools/job-result-retriever/index.ts
+++ b/src/tools/job-result-retriever/index.ts
@@ -4,7 +4,7 @@ import { CallToolResult, McpError, ErrorCode, TextContent } from '@modelcontextp
 import { OpenRouterConfig } from '../../types/workflow.js'; // Although not used directly, keep for ToolExecutor signature
 import logger from '../../logger.js';
 import { registerTool, ToolDefinition, ToolExecutor, ToolExecutionContext } from '../../services/routing/toolRegistry.js';
-import { jobManager, JobStatus, Job } from '../../services/job-manager/index.js'; // Import JobManager and types
+import { jobManager, JobStatus } from '../../services/job-manager/index.js'; // Import JobManager and types
 
 // --- Zod Schema ---
 const getJobResultInputSchemaShape = {

--- a/src/tools/research-manager/index.ts
+++ b/src/tools/research-manager/index.ts
@@ -8,9 +8,10 @@ import { performResearchQuery } from '../../utils/researchHelper.js';
 import { performDirectLlmCall } from '../../utils/llmHelper.js'; // Import the new helper
 import logger from '../../logger.js';
 import { registerTool, ToolDefinition, ToolExecutor, ToolExecutionContext } from '../../services/routing/toolRegistry.js'; // Import ToolExecutionContext
-import { AppError, ApiError, ConfigurationError, ToolExecutionError } from '../../utils/errors.js'; // Import necessary errors
+import { AppError, ToolExecutionError } from '../../utils/errors.js'; // Import necessary errors
 import { jobManager, JobStatus } from '../../services/job-manager/index.js'; // Import job manager & status
 import { sseNotifier } from '../../services/sse-notifier/index.js'; // Import SSE notifier
+import { formatBackgroundJobInitiationResponse } from '../../services/job-response-formatter/index.js';
 
 // Helper function to get the base output directory
 function getBaseOutputDir(): string {
@@ -130,10 +131,11 @@ export const performResearch: ToolExecutor = async (
   logger.info({ jobId, tool: 'research', sessionId }, 'Starting background job.');
 
   // Return immediately
-  const initialResponse: CallToolResult = {
-    content: [{ type: 'text', text: `Research job started for query "${query.substring(0, 50)}...". Job ID: ${jobId}` }],
-    isError: false,
-  };
+  const initialResponse = formatBackgroundJobInitiationResponse(
+    jobId,
+    'Research',
+    `Your research request for query "${query.substring(0, 50)}..." has been submitted. You can retrieve the result using the job ID.`
+  );
 
   // ---> Step 2.5(RM).4: Wrap Logic in Async Block <---
   setImmediate(async () => {

--- a/src/tools/workflow-runner/index.ts
+++ b/src/tools/workflow-runner/index.ts
@@ -10,6 +10,7 @@ import logger from '../../logger.js'; // Import logger
 import { jobManager, JobStatus } from '../../services/job-manager/index.js'; // Import job manager & status
 import { sseNotifier } from '../../services/sse-notifier/index.js'; // Import SSE notifier
 import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'; // Import McpError, ErrorCode
+import { formatBackgroundJobInitiationResponse } from '../../services/job-response-formatter/index.js';
 
 /**
  * Formats the result of a workflow execution into a user-friendly Markdown string.
@@ -90,10 +91,11 @@ export const runWorkflowTool: ToolExecutor = async (
   logger.info({ jobId, tool: 'runWorkflowTool', sessionId: sessionIdForSse, workflowName }, 'Starting background job for workflow.');
 
   // Return immediately
-  const initialResponse: CallToolResult = {
-    content: [{ type: 'text', text: `Workflow '${workflowName}' execution started. Job ID: ${jobId}` }],
-    isError: false,
-  };
+  const initialResponse = formatBackgroundJobInitiationResponse(
+    jobId,
+    `Workflow '${workflowName}' Execution`,
+    `Your request to run workflow '${workflowName}' has been submitted. You can retrieve the result using the job ID.`
+  );
 
   // ---> Step 2.5(WF).4: Wrap Logic in Async Block <---
   setImmediate(async () => {


### PR DESCRIPTION
This pull request introduces the `JobResponseFormatterService` to standardize job initiation responses.

Key changes:
- Added `JobResponseFormatterService` (`src/services/job-response-formatter/index.ts`).
- Updated `job-result-retriever` to use `jobManager` and `JobStatus` directly from the `job-manager` service.
- Added `LOG_LEVEL` and `SSE_PORT` examples to `.env.example`.
- Refined `get-job-result` tool input patterns in `mcp-config.json`.
- Updated `README.md` for `job-result-retriever` with detailed documentation for enhanced job result retrieval and streaming capabilities.

This improves consistency in job responses and enhances documentation for job-related functionalities.