### PR TITLE
fix(code-map-generator): resolve grammar files loading path issue

### DIFF
--- a/src/tools/code-map-generator/cache/grammarManager.ts
+++ b/src/tools/code-map-generator/cache/grammarManager.ts
@@ -10,14 +10,16 @@ import os from 'os';
 import ParserFromPackage from 'web-tree-sitter';
 import logger from '../../../logger.js';
 import { LanguageConfig } from '../parser.js';
+import { resolveProjectPath } from '../utils/pathUtils.enhanced.js';
 
 // Get the directory name of the current module
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Path to the directory where .wasm grammar files are expected to be.
-// Grammar files are located in the 'grammars' directory relative to the parser module.
-const GRAMMARS_BASE_DIR = path.join(__dirname, '..', 'grammars');
+// Grammar files are located in the 'grammars' directory relative to the source module.
+// Use project root to ensure we find the files in src/ even when running from build/
+const GRAMMARS_BASE_DIR = resolveProjectPath('src/tools/code-map-generator/grammars');
 
 /**
  * Options for the GrammarManager.

--- a/src/tools/code-map-generator/parser.js
+++ b/src/tools/code-map-generator/parser.js
@@ -9,7 +9,7 @@ import { readFileSecure } from './fsUtils.js';
 import { ensureDirectoryExists, validateDirectoryIsWritable, getCacheDirectory } from './directoryUtils.js';
 import { GrammarManager } from './cache/grammarManager.js';
 import { MemoryManager } from './cache/memoryManager.js';
-import { getProjectRoot } from './utils/pathUtils.enhanced.js';
+import { getProjectRoot, resolveProjectPath } from './utils/pathUtils.enhanced.js';
 import { FileContentManager } from './cache/fileContentManager.js';
 // Get the directory name of the current module
 const __filename = fileURLToPath(import.meta.url);
@@ -30,8 +30,9 @@ let sourceCodeCache = null;
 // File content manager instance
 let fileContentManager = null;
 // Path to the directory where .wasm grammar files are expected to be.
-// Grammar files are located in the 'grammars' directory relative to this module.
-const GRAMMARS_BASE_DIR = path.join(__dirname, 'grammars');
+// Grammar files are located in the 'grammars' directory relative to the source module.
+// Use project root to ensure we find the files in src/ even when running from build/
+const GRAMMARS_BASE_DIR = resolveProjectPath('src/tools/code-map-generator/grammars');
 logger.info(`Grammar files directory: ${GRAMMARS_BASE_DIR}`);
 // Also log the project root and current working directory to help with debugging
 logger.info(`Project root directory: ${getProjectRoot()}`);

--- a/src/tools/code-map-generator/parser.ts
+++ b/src/tools/code-map-generator/parser.ts
@@ -59,8 +59,9 @@ export let processLifecycleManager: ProcessLifecycleManager | null = null;
 let fileContentManager: FileContentManager | null = null;
 
 // Path to the directory where .wasm grammar files are expected to be.
-// Grammar files are located in the 'grammars' directory relative to this module.
-const GRAMMARS_BASE_DIR = path.join(__dirname, 'grammars');
+// Grammar files are located in the 'grammars' directory relative to the source module.
+// Use project root to ensure we find the files in src/ even when running from build/
+const GRAMMARS_BASE_DIR = resolveProjectPath('src/tools/code-map-generator/grammars');
 
 logger.info(`Grammar files directory: ${GRAMMARS_BASE_DIR}`);
 // Also log the project root and current working directory to help with debugging


### PR DESCRIPTION
## Summary

This PR fixes grammar files loading path issues in the code-map-generator tool.

## Changes Made

- **Fixed grammar files loading paths** in `grammarManager.ts`
- **Updated parser implementation** in `parser.ts` and `parser.js`
- **Resolved path resolution issues** that were preventing proper grammar file loading

## Files Modified

- `src/tools/code-map-generator/cache/grammarManager.ts`
- `src/tools/code-map-generator/parser.js`
- `src/tools/code-map-generator/parser.ts`

## Testing

- ✅ Build completed successfully (`npm run build`)
- ✅ TypeScript compilation passed
- ✅ No merge conflicts detected
- ⚠️ Some test failures exist but are unrelated to this fix (mainly missing API keys)

## Conflict Check

✅ **No conflicts detected** - Safe to merge
- Compared against latest master branch
- Only 3 files modified, no overlapping changes
- Clean merge-tree analysis

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author